### PR TITLE
Add CLI support for custom headers and HTTP method overrides

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"math"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,7 @@ var (
 	tor         string
 	headers     string
 	url         string
+	method      string
 )
 
 const defaultInterval = 10 * time.Second
@@ -38,6 +40,7 @@ func (*Run) SetFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&tor, "tor", "t", "", "TOR endpoint (either socks5://1.1.1.1:1234, or 1.1.1.1:1234).")
 	flags.StringVarP(&url, "url", "u", "", "Target URL to send the attack to.")
 	flags.StringVarP(&headers, "headers", "H", "", "HTTP headers in HEADER=VALUE format, separated by commas.")
+	flags.StringVarP(&method, "method", "m", http.MethodPost, "HTTP method to use when sending requests.")
 }
 
 // GetRequiredFlags returns the server required flags.
@@ -85,7 +88,7 @@ func (*Run) Run() RunCmd {
 					return
 				}
 
-				req := request.NewRequest(int64(isize), url, interval, parsedHeaders)
+				req := request.NewRequest(int64(isize), url, interval, parsedHeaders, method)
 				if tor != "" {
 					req.WithTor(tor)
 				}

--- a/commands/run.go
+++ b/commands/run.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ var (
 	interval    time.Duration
 	size        string
 	tor         string
+	headers     string
 	url         string
 )
 
@@ -35,6 +37,7 @@ func (*Run) SetFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&size, "payload-size", "p", "1MB", "Random generated payload with the given size.")
 	flags.StringVarP(&tor, "tor", "t", "", "TOR endpoint (either socks5://1.1.1.1:1234, or 1.1.1.1:1234).")
 	flags.StringVarP(&url, "url", "u", "", "Target URL to send the attack to.")
+	flags.StringVarP(&headers, "headers", "H", "", "HTTP headers in HEADER=VALUE format, separated by commas.")
 }
 
 // GetRequiredFlags returns the server required flags.
@@ -74,13 +77,15 @@ func (*Run) Run() RunCmd {
 
 		waitgroup.Add(int(concurrents))
 
+		parsedHeaders := parseHeaders(headers)
+
 		for range concurrents {
 			go func() {
 				if isize > math.MaxInt64 {
 					return
 				}
 
-				req := request.NewRequest(int64(isize), url, interval)
+				req := request.NewRequest(int64(isize), url, interval, parsedHeaders)
 				if tor != "" {
 					req.WithTor(tor)
 				}
@@ -95,6 +100,38 @@ func (*Run) Run() RunCmd {
 
 		waitgroup.Wait()
 	}
+}
+
+func parseHeaders(raw string) map[string]string {
+	if raw == "" {
+		return nil
+	}
+
+	headersMap := make(map[string]string)
+
+	entries := strings.Split(raw, ",")
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 {
+			panic("invalid header format: " + entry)
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if key == "" {
+			panic("header name cannot be empty")
+		}
+
+		headersMap[key] = value
+	}
+
+	return headersMap
 }
 
 func newRun() command {

--- a/request/request.go
+++ b/request/request.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/darkweak/rudy/logger"
@@ -27,8 +28,14 @@ type Request interface {
 }
 
 // NewRequest creates the request.
-func NewRequest(size int64, u string, delay time.Duration, headers map[string]string) Request {
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, u, nil)
+func NewRequest(size int64, u string, delay time.Duration, headers map[string]string, method string) Request {
+	if method == "" {
+		method = http.MethodPost
+	} else {
+		method = strings.ToUpper(method)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), method, u, nil)
 	req.ProtoMajor = 1
 	req.ProtoMinor = 1
 	req.TransferEncoding = []string{"chunked"}

--- a/request/request.go
+++ b/request/request.go
@@ -27,12 +27,16 @@ type Request interface {
 }
 
 // NewRequest creates the request.
-func NewRequest(size int64, u string, delay time.Duration) Request {
+func NewRequest(size int64, u string, delay time.Duration, headers map[string]string) Request {
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, u, nil)
 	req.ProtoMajor = 1
 	req.ProtoMinor = 1
 	req.TransferEncoding = []string{"chunked"}
 	req.Header = make(map[string][]string)
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
 
 	return &request{
 		client:      http.DefaultClient,


### PR DESCRIPTION
Add --headers flag to the run command so users can pass comma-separated HEADER=VALUE pairs that are parsed into request headers before dispatch.

Introduce a --method flag, defaulting to POST, and propagate the selected HTTP verb through request creation, ensuring the value is upper-cased and applied to every outgoing request.
